### PR TITLE
Client.submit_job() should return the job id as int

### DIFF
--- a/nmpi/nmpi_user.py
+++ b/nmpi/nmpi_user.py
@@ -174,7 +174,7 @@ class Client(object):
                             else:
                                 raise Exception("Unhandled error in Authentication." + rNMPI2.url)
                     else:
-                        raise Exception("Communication error")
+                        raise Exception("Communication error: Status code {} from HBP, expected 200".format(rNMPI2.status_code))
                 else:
                     raise Exception("Something went wrong. No text.")
             else:

--- a/nmpi/nmpi_user.py
+++ b/nmpi/nmpi_user.py
@@ -266,6 +266,8 @@ class Client(object):
         """
         Submit a job to the platform.
 
+        Returns the job id (int).
+
         Arguments:
 
         source : the Python script to be run, the URL of a public version
@@ -302,7 +304,9 @@ class Client(object):
             job['hardware_config'] = config
         result = self._post(self.resource_map["queue"], job)
         print("Job submitted")
-        return result
+        job_id_str = result.split('/')[-1]
+        job_id_int = int(job_id_str)
+        return job_id_int
 
     def job_status(self, job_id):
         """


### PR DESCRIPTION
`Client.submit_job()` currently returns a path on the webserver that points to the job (I think). But what the user probably wants to get back is the numeric job id, which can then be used e.g. in `Client.job_status()`.
The proposed change modifies `Client.submit_job` to return the numeric job id, and updates the documentation accordingly.
I'm not sure whether this would break any existing functionality, though. If it does, one could instead add a function that extracts the job id from the return value of `Client.submit_job()`. In any case, the return value of `Client.submit_job()` should be documented.
