### PR TITLE
report status code on communication error

### DIFF
--- a/nmpi/nmpi_user.py
+++ b/nmpi/nmpi_user.py
@@ -201,7 +201,7 @@ class Client(object):
                             else:
                                 raise Exception("Unhandled error in Authentication." + rNMPI2.url)
                     else:
-                        raise Exception("Communication error")
+                        raise Exception("Communication error. Status code {} from HBP, expected 200".format(rNMPI2.status_code))
                 else:
                     raise Exception("Something went wrong. No text.")
             else:


### PR DESCRIPTION
received error 500 when connecting to the collab today, but had to fire up a debugger to obtain the status code. This PR adds the status code to the exception message, like the other messages already do.

Thanks to @sesutton for pointing out the error.